### PR TITLE
Fixed edge type in RandomRegular graphs

### DIFF
--- a/pygsp2/graphs/randomregular.py
+++ b/pygsp2/graphs/randomregular.py
@@ -63,7 +63,7 @@ class RandomRegular(Graph):
             raise ValueError('input error: N*d must be even!')
 
         # a list of open half-edges
-        U = np.kron(np.ones(k), np.arange(N))
+        U = np.kron(np.ones(k), np.arange(N)).astype(int)
 
         # the graphs adjacency matrix
         A = sparse.lil_matrix(np.zeros((N, N)))


### PR DESCRIPTION
In [randomregular.py](https://github.com/epfl-lts2/pygsp/blob/master/pygsp/graphs/randomregular.py) changed

```python
# a list of open half-edges
U = np.kron(np.ones(k), np.arange(N))
```

into

```python
# a list of open half-edges
U = np.kron(np.ones(k), np.arange(N)).astype(int)
```