### PR TITLE
Add edge_percent parameter to filter visible edges in plots

### DIFF
--- a/pygsp2/plotting.py
+++ b/pygsp2/plotting.py
@@ -509,10 +509,12 @@ def _plot_graph(G, vertex_color, vertex_size, highlight, edges, edge_color, edge
 @_plt_handle_figure
 def _plt_plot_graph(G, vertex_color, vertex_size, highlight, edges, edge_color, edge_width, indices, colorbar, limits, ax, cmap,
                     alphan, alphav, edge_weights):
-
+    
     mpl, plt, mplot3d = _import_plt()
     plt.set_cmap(cmap)
     cmap = mpl.colormaps.get_cmap(cmap)
+
+    edge_percent = G.plotting.get('edge_percent', 100)
 
     def is_color(color):
         mpl, _, _ = _import_plt()
@@ -526,6 +528,15 @@ def _plt_plot_graph(G, vertex_color, vertex_size, highlight, edges, edge_color, 
     if edges and (G.coords.ndim != 1):  # No edges for 1D plots.
 
         sources, targets, _ = G.get_edge_list()
+        
+        if edge_percent < 100:
+            _, _, weights = G.get_edge_list()
+            weights = np.asarray(weights)
+            threshold = np.percentile(weights, 100 - edge_percent)
+            mask = weights >= threshold
+            sources = sources[mask]
+            targets = targets[mask]
+            
         edges = [
             G.coords[sources],
             G.coords[targets],


### PR DESCRIPTION
This PR addresses [issue #88](https://github.com/gsp-eeg/PyGSP2/issues/88).

We added support for visually filtering a percentage of the strongest edges in a graph using the new `edge_percent` parameter. This makes it easier to interpret dense or fully connected adjacency matrices, especially in EEG-related graph visualizations, by displaying only the most relevant connections without altering the original graph structure.

Minimal example for demonstration:

```python
import numpy as np
import matplotlib.pyplot as plt
from pygsp2.graphs import Graph

# Create adjacency matrix with random weights
np.random.seed(42)
N = 10
W = np.zeros((N, N))
for i in range(N):
    for j in range(N):
        if i != j and np.random.rand() < 0.6:
            W[i, j] = np.random.choice([0.1, 0.3, 0.6, 0.9, 1.5], p=[0.4, 0.2, 0.2, 0.1, 0.1])

# Create graph
G = Graph(W)

# Set circular 2D coordinates
theta = np.linspace(0, 2 * np.pi, N, endpoint=False)
coords = np.stack([0.5 * np.cos(theta), 0.5 * np.sin(theta)], axis=1)
G.set_coordinates(coords)

# Plot side-by-side with and without edge filtering
fig, axs = plt.subplots(1, 2, figsize=(12, 6))

# Plot all edges
G.plot(ax=axs[0], edge_width=W[W > 0])
axs[0].set_title("100% edges")

# Plot top 10% strongest edges
G.plotting['edge_percent'] = 10
G.plot(ax=axs[1], edge_width=W[W > 0])
axs[1].set_title("Top 10% edges")
axs[1].set_aspect('equal', adjustable='box')

plt.tight_layout()
plt.show()
```

Expected output image:

![download](https://github.com/user-attachments/assets/8626b04c-c34e-4db8-b3e9-e8a779e04eec)

This minimal enhancement keeps the visualization behavior intuitive while preserving the underlying graph data.

Let us know if any adjustments are required or if additional tests are needed.
