### PR TITLE
Make edge_percent an explicit parameter of plot() and _plot_graph()

### DIFF
--- a/pygsp2/graphs/graph.py
+++ b/pygsp2/graphs/graph.py
@@ -998,13 +998,16 @@ class Graph(FourierMixIn, DifferenceMixIn, IOMixIn, LayoutMixIn):
         assert self.n_edges == sources.size == targets.size == weights.size
         return sources, targets, weights
 
-    def plot(self, vertex_color=None, vertex_size=None, highlight=[], edges=None, edge_color=None, edge_width=None, indices=False,
-             colorbar=True, limits=None, ax=None, title=None, backend=None, cmap=None, alphan=1, alphav=1, edge_weights=None):
+    def plot(self, vertex_color=None, vertex_size=None, highlight=[], edges=None,
+         edge_color=None, edge_width=None, indices=False, colorbar=True,
+         limits=None, ax=None, title=None, backend=None, cmap=None,
+         alphan=1, alphav=1, edge_weights=None, edge_percent=100):
         r"""Docstring overloaded at import time."""
         from pygsp2.plotting import _plot_graph
         return _plot_graph(self, vertex_color=vertex_color, vertex_size=vertex_size, highlight=highlight, edges=edges,
-                           indices=indices, colorbar=colorbar, edge_color=edge_color, edge_width=edge_width, limits=limits, ax=ax,
-                           title=title, backend=backend, cmap=cmap, alphan=alphan, alphav=alphav, edge_weights=edge_weights)
+                   indices=indices, colorbar=colorbar, edge_color=edge_color, edge_width=edge_width, limits=limits, ax=ax,
+                   title=title, backend=backend, cmap=cmap, alphan=alphan, alphav=alphav, edge_weights=edge_weights,
+                   edge_percent=edge_percent)
 
 
     def plot_signal(self, *args, **kwargs):

--- a/pygsp2/plotting.py
+++ b/pygsp2/plotting.py
@@ -284,8 +284,10 @@ def _plt_plot_filter(filters, n, eigenvalues, sum, labels, ax, **kwargs):
     ax.set_ylabel(r'filter response $g(\lambda)$')
 
 
-def _plot_graph(G, vertex_color, vertex_size, highlight, edges, edge_color, edge_width, indices, colorbar, limits, ax, title,
-                backend, cmap, alphan, alphav, edge_weights):
+def _plot_graph(G, vertex_color, vertex_size, highlight, edges, edge_color,
+                edge_width, indices, colorbar, limits, ax, title,
+                backend, cmap, alphan, alphav, edge_weights,
+                edge_percent=100):
     r"""Plot a graph with signals as color or vertex size.
 
     Parameters
@@ -464,6 +466,21 @@ def _plot_graph(G, vertex_color, vertex_size, highlight, edges, edge_color, edge
 
     if edges is None:
         edges = G.Ne < 10e3
+
+    if edge_percent < 100:
+        W = G.W.toarray()
+        threshold = np.percentile(W[W > 0], 100 - edge_percent)
+        W_filtered = np.where(W >= threshold, W, 0)
+        G = G.__class__(W_filtered, coords=G.coords, plotting=G.plotting)
+
+    # Recompute edge_width if a previous edge array is provided
+    if isinstance(edge_width, np.ndarray) and len(edge_width) == G.Ne:
+        edge_width = edge_width
+    elif isinstance(edge_width, np.ndarray):
+        # If edge_width comes from the original (unfiltered) adjacency,
+        # adapt it to the filtered graph using the non-zero entries of W_filtered
+        W_arr = W_filtered[W_filtered > 0]
+        edge_width = G.plotting['edge_width'] * 2 * normalize(W_arr)
 
     if edge_color is None:
         edge_color = (G.plotting['edge_color'], )


### PR DESCRIPTION
This PR replaces the use of `G.plotting['edge_percent']` with an explicit `edge_percent` parameter in both `Graph.plot()` and the internal `_plot_graph()` function.

This change addresses the issue raised by @aweinstein in [this comment](https://github.com/gsp-eeg/PyGSP2/pull/94#discussion_r1604424434), where `edge_percent` should not be stored in the graph state.

---

### Minimal example

```python
import numpy as np
import matplotlib.pyplot as plt
from pygsp2.graphs import Graph

# Create random adjacency matrix
np.random.seed(42)
N = 10
W = np.zeros((N, N))
for i in range(N):
    for j in range(N):
        if i != j and np.random.rand() < 0.6:
            W[i, j] = np.random.choice([0.1, 0.3, 0.6, 0.9, 1.5], p=[0.4, 0.2, 0.2, 0.1, 0.1])

# Create graph
G = Graph(W)

# Set 2D coordinates
theta = np.linspace(0, 2 * np.pi, N, endpoint=False)
coords = np.stack([0.5 * np.cos(theta), 0.5 * np.sin(theta)], axis=1)
G.set_coordinates(coords)

# Plot both 100% and filtered 10% edges
fig, axs = plt.subplots(1, 2, figsize=(12, 6))
G.plot(ax=axs[0], edge_width=W[W > 0])
axs[0].set_title("100% edges")
axs[0].set_aspect('equal', adjustable='box')

G.plot(ax=axs[1], edge_percent=10, edge_width=W[W > 0])
axs[1].set_title("Top 10% edges")
axs[1].set_aspect('equal', adjustable='box')

plt.tight_layout()
plt.show()
```

This is the output generated by the code above:

![download](https://github.com/user-attachments/assets/9d6128dc-d866-446b-901d-b288574c5aa5)

This verifies that edge_percent now behaves correctly when passed as a method argument and filters edges visually as expected.

Thanks again for the helpful feedback.